### PR TITLE
Docker: cache downloaded dependencies

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Only the .dockerignore file at the root directory of the build context is used
+
+.git
+.gitignore
+**/Dockerfile
+
+# Build and Run Artifacts
+**/.gradle
+**/bin
+**/build
+**/log
+
+# Documentation
+**/*.raml
+**/*.md
+
+# Gradle Wrapper
+**/gradle
+**/gradlew
+**/gradlew.bat

--- a/.env-template
+++ b/.env-template
@@ -1,3 +1,3 @@
 GITHUB_USER=
 GITHUB_TOKEN=
-JAVA_OPTS=-Xms1G -Xmx2G -Dfile.encoding=UTF-8
+JAVA_OPTS="-Xms1G -Xmx2G -Dfile.encoding=UTF-8"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,77 @@
-ARG  GRADLE_VERSION=jdk11
+# The Dockerfile is broken into three steps.
+
+# 1. Download the dependencies, including Carnival
+# - Full build environment
+# - Uses: GitHub credentials, project config files
+
+# 2. Build the app
+# - Full build environment
+# - Uses: Cached dependencies from (1), app source and config
+
+# 3. Run the app
+# - Stripped down environment with a JVM
+# - Uses: JAR from (2)
+
+ARG GRADLE_VERSION=jdk11
+
+# Stage 1: Downloads and caches dependencies, including Carnival
+FROM gradle:${GRADLE_VERSION} as cache
+
+ARG GITHUB_USER
+ARG GITHUB_TOKEN
+
+ARG JAVA_OPTS
+
+ENV GRADLE_OPTS ${JAVA_OPTS}
+
+ENV GRADLE_USER_HOME /home/gradle
+
+COPY build.gradle      ${GRADLE_USER_HOME}
+COPY gradle.properties ${GRADLE_USER_HOME}
+COPY settings.gradle   ${GRADLE_USER_HOME}
+
+WORKDIR ${GRADLE_USER_HOME}
+
+RUN echo && \
+    echo Proceding to Download Dependencies && \
+    # Will show downloads occurring
+    # gradle dependencies -i --stacktrace
+    gradle dependencies 
+
+# Message when downloading dependencies. Fix?
+# Cache entries evicted. In-memory cache of /home/gradle/.gradle/checksums/sha1-checksums.bin: Size{400} MaxSize{400}, CacheStats{hitCount=241, missCount=561, loadSuccessCount=561, loadExceptionCount=0, totalLoadTime=78824764, evictionCount=161} 
+# Performance may suffer from in-memory cache misses. Increase max heap size of Gradle build process to reduce cache misses.
+
+# Stage 2: Builds The Application
 FROM gradle:${GRADLE_VERSION} AS builder
 
-# Install linux utils
-RUN apt-get update && \
-#    apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends \
-      dos2unix \
-      rename   \
-      sed      \
-      git      \
-      &&       \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+ARG GITHUB_USER
+ARG GITHUB_TOKEN
 
-### Development Image
+ARG JAVA_OPTS
+
+ENV GRADLE_OPTS ${JAVA_OPTS}
 
 ENV CARNIVAL_MICRONAUT      /opt/carnival-micronaut
 ENV CARNIVAL_MICRONAUT_HOME /opt/carnival-micronaut-home
 ENV APOC_HOME               /opt/neo4j/plugins
 ENV APOC_VERSION            3.4.0.7
-ENV CARNIVAL_LIB_SRC        /opt/carnival
-ENV GRADLE_HOME             /opt/gradle
+#ENV CARNIVAL_LIB_SRC        /opt/carnival
+ENV GRADLE_USER_HOME        /home/gradle
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+      dos2unix \
+      git      \
+      rename   \
+      sed      \
+      &&       \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Bring in cached dependencies
+COPY --from=cache ${GRADLE_USER_HOME}/caches ${GRADLE_USER_HOME}/caches
 
 RUN mkdir ${CARNIVAL_MICRONAUT}
 
@@ -33,15 +84,12 @@ COPY micronaut-cli.yml ${CARNIVAL_MICRONAUT}/.
 
 COPY ./src ${CARNIVAL_MICRONAUT}/src
 
-ARG GITHUB_USER
-ARG GITHUB_TOKEN
-
-ARG JAVA_OPTS
-
 WORKDIR ${CARNIVAL_MICRONAUT}
 
+#RUN gradle shadowJar -i --stacktrace
 RUN gradle shadowJar
 
+# Stage 3: Runs The App
 FROM adoptopenjdk/openjdk11-openj9:jdk-11.0.1.13-alpine-slim AS app
 
 ENV CARNIVAL_MICRONAUT      /opt/carnival-micronaut

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Demonstration Micronaut server with a Carnival graph resource.
 
-# Set up instructions with Docker
+## Set up instructions with Docker
 
 tl;dr
 
@@ -29,19 +29,19 @@ Note that as non-profit institutions, we can use the free "Personal" license.
 
 *No. You and your assistants may use Docker Desktop for free with a Docker Personal subscription.*
 
-## 1. Set up GitHub
+### 1. Set up GitHub
 
 Set up your GitHub environment to work with [GitHub Packages](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry).
 
 Generate a [Personal Access Token](https://github.com/settings/tokens) with read:packages rights. Be sure to save it as you won't be able to look it up on GitHub later.
 
-## 2. Clone Carnival Micronaut
+### 2. Clone Carnival Micronaut
 
 ```
 git clone https://github.com/pmbb-ibi/carnival-micronaut.git
 ```
 
-## 3. Put credentials in .env
+### 3. Put credentials in .env
 
 ```
 cd carnival-micronaut
@@ -51,7 +51,7 @@ edit .env-template, save as .env
 Edit .env-template, inserting your GitHub username and access token. Save as .env
 
 
-## 4. Build and run the Hello World app
+### 4. Build and run the Hello World app
 
 ```
 sudo docker-compose build
@@ -60,22 +60,22 @@ sudo docker-compose up
 
 There should now be a server running at http://localhost:5858.
 
-# Set up instructions without Docker
+## Set up instructions without Docker
 
 Prerequisite: JDK 11
 
-## 1. Set up GitHub
+### 1. Set up GitHub
 
 Set up your GitHub environment to work with [GitHub Packages](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry).
 
-## 2. Clone Carnival Micronaut
+### 2. Clone Carnival Micronaut
 
 ```
 git clone https://github.com/pmbb-ibi/carnival-micronaut.git
 ```
 
 <!--
-## 3. Create Home Directory
+### 3. Create Home Directory
 
 The Carnival Micronaut Home directory will us the working directory for Carnival Micronaut.  It will include all configuration and data.
 
@@ -86,7 +86,7 @@ export CARNIVAL_MICRONAUT_HOME=/full/path/to/carnival-micronaut/carnival-microna
 ```
 -->
 
-## 3. Build and run the Hello World app
+### 3. Build and run the Hello World app
 
 ```
 cd carnival-micronaut
@@ -96,9 +96,16 @@ cd carnival-micronaut
 There should now be a server running at http://localhost:5858.
 
 
-## 4. Create and run Docker container
+### 4. Create and run Docker container
 
 ```
 ./docker-build.zsh
 docker run --publish 5858:5858 carnival-micronaut:0.1
 ```
+
+## Testing with Docker
+Run tests with the following:
+```
+docker-compose -f docker-compose-test.yml up
+```
+This will run the unit tests. The test results will be printed in the docker log. An exit code of 0 will be returned if the tests pass, otherwise a non-zero code will be returned.

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
         maven {
             name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/pmbb-ibi/carnival")
+            url = uri("https://maven.pkg.github.com/carnival-data/carnival")
             credentials {
                 username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_USER")
                 password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
@@ -31,7 +31,7 @@ repositories {
     mavenCentral()
     maven {
         name = "GitHubPackages"
-        url = uri("https://maven.pkg.github.com/pmbb-ibi/carnival")
+        url = uri("https://maven.pkg.github.com/carnival-data/carnival")
         credentials {
             username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_USER")
             password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,0 +1,22 @@
+version: "3.7"
+
+
+# mounted volume is used so that when code changes, 
+# tests can be rerun without needing to rebuild
+
+services:
+  tester:
+    build:
+      context: .
+      target: base
+      args:
+        GITHUB_USER: ${GITHUB_USER}
+        GITHUB_TOKEN: ${GITHUB_TOKEN}
+        JAVA_OPTS: ${JAVA_OPTS}
+    command: "gradle test --no-daemon"
+    tty: true
+    stdin_open: true
+
+    volumes:
+      - "./src:/opt/carnival-micronaut/src:ro"
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,13 +13,3 @@ services:
 
     tty: true
     stdin_open: true
-
-#    command: "env"
-#    command: java -Dcom.sun.management.jmxremote -noverify ${JAVA_OPTS} -Dcarnival.home=/opt/carnival-micronaut-home -Dlogback.configurationFile=/opt/carnival-micronaut-home/config/logback.xml -Dmicronaut.config.files=/opt/carnival-micronaut-home/config/application.yml -jar /opt/carnival-micronaut/build/libs/carnival-micronaut-0.1-all.jar
-#    command: 
-#java -Dcom.sun.management.jmxremote -noverify ${JAVA_OPTS} 
-#-Dcarnival.home=/opt/carnival-micronaut-home 
-#-Dlogback.configurationFile=/opt/carnival-micronaut-home/config/logback.xml 
-#-Dmicronaut.config.files=/opt/carnival-micronaut-home/config/application.yml 
-#-jar /opt/carnival-micronaut/build/libs/carnival-micronaut-0.1-all.jar
-


### PR DESCRIPTION
The first time you build, with or without Docker, Gradle downloads all dependencies. Normally Gradle caches those downloads.

However, currently with Docker, each time you change the app source and rebuild, the dependencies all redownload.

This PR caches the dependency downloads, greatly speeding up app rebuilds under Docker.