### PR TITLE
Consume Carnival library from Maven Central

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -1,3 +1,1 @@
-GITHUB_USER=
-GITHUB_TOKEN=
 JAVA_OPTS="-Xms1G -Xmx2G -Dfile.encoding=UTF-8"

--- a/README.md
+++ b/README.md
@@ -12,10 +12,8 @@ tl;dr
 ```
 Install git
 Install Docker Desktop
-Create GitHub Personal Access Token with read:packages rights, https://github.com/settings/tokens
 git clone https://github.com/carnival-data/carnival-micronaut.git
 cd carnival-micronaut
-edit .env-template, save as .env
 sudo docker-compose build
 sudo docker-compose up
 Open a browser to http://localhost:5858
@@ -37,29 +35,13 @@ Note that as non-profit institutions, we can use the free "Personal" license.
 
 *No. You and your assistants may use Docker Desktop for free with a Docker Personal subscription.*
 
-### 1. Set up GitHub
-
-Set up your GitHub environment to work with [GitHub Packages](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry).
-
-Generate a [Personal Access Token](https://github.com/settings/tokens) with read:packages rights. Be sure to save it as you won't be able to look it up on GitHub later.
-
-### 2. Clone Carnival Micronaut
+### 1. Clone Carnival Micronaut
 
 ```
 git clone https://github.com/pmbb-ibi/carnival-micronaut.git
 ```
 
-### 3. Put credentials in .env
-
-```
-cd carnival-micronaut
-edit .env-template, save as .env
-```
-
-Edit .env-template, inserting your GitHub username and access token. Save as .env
-
-
-### 4. Build and run the Hello World app
+### 2. Build and run the app
 
 ```
 sudo docker-compose build

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,22 @@
 buildscript {
     repositories {
-        mavenCentral()
         maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/carnival-data/carnival")
-            credentials {
-                username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_USER")
-                password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
-            }
+            name = "MavenCentralSnapshots"
+            url 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
         }
+        mavenCentral()
+        // maven {
+        //     name = "GitHubPackages"
+        //     url = uri("https://maven.pkg.github.com/carnival-data/carnival")
+        //     credentials {
+        //         username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_USER")
+        //         password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+        //     }
+        // }
         mavenLocal()
     }
     dependencies {
-        classpath group:'org.carnival', name:'carnival-gradle', version:'2.1.0'
+        classpath group:'io.github.carnival-data', name:'carnival-gradle', version:'2.1.4-SNAPSHOT'
     }    
 }
 
@@ -28,15 +32,19 @@ version "0.1"
 group "org.carnival"
 
 repositories {
-    mavenCentral()
     maven {
-        name = "GitHubPackages"
-        url = uri("https://maven.pkg.github.com/carnival-data/carnival")
-        credentials {
-            username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_USER")
-            password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
-        }
+        name = "MavenCentralSnapshots"
+        url 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
     }
+    mavenCentral()
+    // maven {
+    //     name = "GitHubPackages"
+    //     url = uri("https://maven.pkg.github.com/carnival-data/carnival")
+    //     credentials {
+    //         username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_USER")
+    //         password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+    //     }
+    // }
 }
 
 micronaut {

--- a/build.gradle
+++ b/build.gradle
@@ -1,22 +1,25 @@
 buildscript {
     repositories {
+        // We may have to manually comment out earlier repos to pull from later ones (disable maven to use github)
         maven {
             name = "MavenCentralSnapshots"
-            url 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
+            def snapshotsRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+            def releasesRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+            url = carnivalVersion.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
         }
         mavenCentral()
-        // maven {
-        //     name = "GitHubPackages"
-        //     url = uri("https://maven.pkg.github.com/carnival-data/carnival")
-        //     credentials {
-        //         username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_USER")
-        //         password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
-        //     }
-        // }
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/carnival-data/carnival")
+            credentials {
+                username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_USER")
+                password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+            }
+        }
         mavenLocal()
     }
     dependencies {
-        classpath group:'io.github.carnival-data', name:'carnival-gradle', version:'2.1.4-SNAPSHOT'
+        classpath group:'io.github.carnival-data', name:'carnival-gradle', version:project.findProperty("carnivalVersion")
     }    
 }
 
@@ -29,22 +32,25 @@ plugins {
 apply plugin: 'carnival.application'
 
 version "0.1"
-group "org.carnival"
+group "io.github.carnival-data"
 
 repositories {
+    // We may have to manually comment out earlier repos to pull from later ones (disable maven to use github)
     maven {
         name = "MavenCentralSnapshots"
-        url 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
+        def snapshotsRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+        def releasesRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+        url = carnivalVersion.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
     }
     mavenCentral()
-    // maven {
-    //     name = "GitHubPackages"
-    //     url = uri("https://maven.pkg.github.com/carnival-data/carnival")
-    //     credentials {
-    //         username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_USER")
-    //         password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
-    //     }
-    // }
+    maven {
+        name = "GitHubPackages"
+        url = uri("https://maven.pkg.github.com/carnival-data/carnival")
+        credentials {
+            username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_USER")
+            password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+        }
+    }
 }
 
 micronaut {

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -10,9 +10,7 @@ services:
       context: .
       target: base
       args:
-        GITHUB_USER: ${GITHUB_USER}
-        GITHUB_TOKEN: ${GITHUB_TOKEN}
-        JAVA_OPTS: ${JAVA_OPTS}
+        JAVA_OPTS: ${JAVA_OPTS:-="-Xms1G -Xmx2G -Dfile.encoding=UTF-8"}
     command: "gradle test --no-daemon"
     tty: true
     stdin_open: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,7 @@ services:
     build:
       context: .
       args:
-        GITHUB_USER: ${GITHUB_USER}
-        GITHUB_TOKEN: ${GITHUB_TOKEN}
-        JAVA_OPTS: ${JAVA_OPTS}
+        JAVA_OPTS: ${JAVA_OPTS:-="-Xms1G -Xmx2G -Dfile.encoding=UTF-8"}
       target: app
     ports:
       - "5858:5858"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
+carnivalVersion=2.1.4-SNAPSHOT
 micronautVersion=2.4.2
 org.gradle.caching=true


### PR DESCRIPTION
1.
Carnival library version is set in gradle.properties.

2.
As currently written, we may have to manually disable repositories in build.gradle.

Repos are specified in order:
-maven snapshot or staging, depending on if we are using a Carnival snapshot release or not
-maven central
-github

The first repo that contains the correct group id will be used. However the correct version of Carnival may only be in another repo.

You can test this behavior by changing gradle.properties. 2.1.4-SNAPSHOT is only in the Central Snapshot repo. 2.1.0 is only in GitHub releases.